### PR TITLE
bugfix: hanging loader on profile update

### DIFF
--- a/src/firebase/FirebaseAppProvider.tsx
+++ b/src/firebase/FirebaseAppProvider.tsx
@@ -28,8 +28,8 @@ export function FirebaseAppProvider({children}: React.PropsWithChildren<any>) {
     googleProvider: new firebase.auth.GoogleAuthProvider(),
   });
   let authState = useAuthState(auth);
-  let {user, loading, failedToLoad} = authState;
-  let usernamesHook = useUsernames();
+  let {user, loading, failedToLoad, isAuthenticated} = authState;
+  let usernamesHook = useUsernames({isAuthenticated});
 
   return (
     <FirebaseAppContext.Provider

--- a/src/firebase/useAuthState.ts
+++ b/src/firebase/useAuthState.ts
@@ -40,7 +40,10 @@ export function useAuthState(auth: firebase.auth.Auth): FirebaseAuthState {
       (valid, userModel) => {
         setUserModel(userModel);
         setLoadingUserModel(false);
-        if (!valid) history.push('/profile/update');
+
+        if (user && !valid) {
+          history.push('/profile/update');
+        }
       }
     );
 

--- a/src/firebase/useUsernames.tsx
+++ b/src/firebase/useUsernames.tsx
@@ -9,23 +9,40 @@ export interface IUsernamesHook {
   uids: string[];
 }
 
-export function useUsernames(): IUsernamesHook {
+export function useUsernames({isAuthenticated}): IUsernamesHook {
   let [usernamesTable, setUsernames] = useState<DatabaseModel['usernames']>({});
   let [loading, setLoading] = useState<boolean>(true);
+  console.log('usernames hook rendering.');
 
   useEffect(() => {
+    console.log('usernames loading.');
+    if (!isAuthenticated) return;
     let unsub = databaseListener(
       FirebaseApp.database().ref('usernames'),
       'value',
       (s) => {
-        setUsernames(s.val());
+        setUsernames({...s.val()});
+      },
+      console.error,
+      () => {
+        console.log('usernames completed.');
         setLoading(false);
       }
     );
     return () => {
       unsub();
     };
-  }, []);
+  }, [isAuthenticated]);
+
+  if (!isAuthenticated) {
+    console.info('cannot access usernames unless authenticated');
+    return {
+      loading: false,
+      usernamesTable: {},
+      usernames: [],
+      uids: [],
+    };
+  }
 
   return {
     loading,

--- a/src/pages/ProfileUpdatePage.tsx
+++ b/src/pages/ProfileUpdatePage.tsx
@@ -29,7 +29,10 @@ export function ProfileUpdatePage(props) {
   );
   let {userRepo} = repos;
   let {usernames, loading} = usernamesHook;
-  if (loading) return <Loader />;
+  if (loading) {
+    console.info('attempting to load profile update page ');
+    return <Loader />;
+  }
   let validation = new UserNameValidation();
 
   return (


### PR DESCRIPTION
when logging in an user did not have a username, the app correctly moves user to profile/update endpoint to prompt for a username -- however, it would display a loader that spun forever until refreshing the page. this was happening because the usernames hook should have been dependent on whether or not the client is authenticated.